### PR TITLE
Correct the package name of rocprofiler-sdk

### DIFF
--- a/cmake/rocprofiler_config_packaging.cmake
+++ b/cmake/rocprofiler_config_packaging.cmake
@@ -199,9 +199,9 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 # -------------------------------------------------------------------------------------- #
 # Make proper version for appending
 # Default Value is 99999
-set(ROCM_VERSION_FOR_PACKAGE "99999")
+set(ROCM_VERSION_FOR_PACKAGE "99999" CACHE STRING "")
 if(DEFINED ENV{ROCM_LIBPATCH_VERSION})
-    set(ROCM_VERSION_FOR_PACKAGE $ENV{ROCM_LIBPATCH_VERSION})
+    set(ROCM_VERSION_FOR_PACKAGE "$ENV{ROCM_LIBPATCH_VERSION}" CACHE STRING "" FORCE)
 endif()
 #Prepare final version for the CPACK use
 set(CPACK_PACKAGE_VERSION

--- a/cmake/rocprofiler_config_packaging.cmake
+++ b/cmake/rocprofiler_config_packaging.cmake
@@ -197,9 +197,14 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 # Prepare final version for the CPACK use
 #
 # -------------------------------------------------------------------------------------- #
-
+# Make proper version for appending
+# Default Value is 99999
+set(ROCM_VERSION_FOR_PACKAGE "99999")
+if(DEFINED ENV{ROCM_LIBPATCH_VERSION})
+    set(ROCM_VERSION_FOR_PACKAGE $ENV{ROCM_LIBPATCH_VERSION})
+endif()
+#Prepare final version for the CPACK use
 set(CPACK_PACKAGE_VERSION
-    "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}"
-    )
+    "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}.${ROCM_VERSION_FOR_PACKAGE}")
 
 include(CPack)


### PR DESCRIPTION
ROCM VERSION(for ex: 60300) was missing in the package name. Added the same

# Details about PR

___Do not mention proprietary info or link to internal work items in this PR.___

__Work item: SWDEV-487872

__What were the changes?__  
Added ROCM VERSION to package name

__Why were the changes made?__  
Package name is missing ROCM VERSION

__How was the outcome achieved?__  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

__Additional Documentation:__  
_What else should the reviewer know?_

## Approval Checklist

___Do not approve until these items are satisfied.___

- [ ] Verify the CHANGELOG has been updated.
- [ ] Verify if the unit test has been added.
- [ ] Verify if the integration test is added.
- [ ] Verify if the documentaiton has been updated.
