### PR TITLE
Increase maximum counter capacity

### DIFF
--- a/source/lib/rocprofiler-sdk-tool/helper.hpp
+++ b/source/lib/rocprofiler-sdk-tool/helper.hpp
@@ -266,13 +266,13 @@ struct rocprofiler_tool_record_counter_t
 
 struct rocprofiler_tool_counter_collection_record_t
 {
-    rocprofiler_dispatch_counting_service_data_t       dispatch_data    = {};
-    std::array<rocprofiler_tool_record_counter_t, 512> records          = {};
-    uint64_t                                           thread_id        = 0;
-    uint64_t                                           arch_vgpr_count  = 0;
-    uint64_t                                           sgpr_count       = 0;
-    uint64_t                                           lds_block_size_v = 0;
-    uint64_t                                           counter_count    = 0;
+    rocprofiler_dispatch_counting_service_data_t        dispatch_data    = {};
+    std::array<rocprofiler_tool_record_counter_t, 4096> records          = {};
+    uint64_t                                            thread_id        = 0;
+    uint64_t                                            arch_vgpr_count  = 0;
+    uint64_t                                            sgpr_count       = 0;
+    uint64_t                                            lds_block_size_v = 0;
+    uint64_t                                            counter_count    = 0;
 
     template <typename ArchiveT>
     void save(ArchiveT& ar) const


### PR DESCRIPTION
# PR Details

Increases maximum counter capacity from 512 -> 4096 to avoid  crash when running rocprofv3 with Omniperf.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Technical details

Addresses SWDEV-484742 Exceeded maximum counter capacity

## Added/updated tests?

_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, Does not apply to this PR.

## Updated CHANGELOG?

_Needed for Release updates for a ROCm release._

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.
