### PR TITLE
Excluding Readme.md to prevent being improperly rendered in the docs page

### DIFF
--- a/source/docs/rocprofiler-sdk.dox.in
+++ b/source/docs/rocprofiler-sdk.dox.in
@@ -139,12 +139,13 @@ FILE_PATTERNS          = *.h \
                          *.tcc \
                          conf.py
 RECURSIVE              = YES
-EXCLUDE                =
+EXCLUDE                = @SOURCE_DIR@/README.md
 EXCLUDE_SYMLINKS       = YES
 EXCLUDE_PATTERNS       = */.git/* \
                          @SOURCE_DIR@/**/tests/* \
                          @SOURCE_DIR@/**/scripts/* \
-                         @SOURCE_DIR@/**/docs/*
+                         @SOURCE_DIR@/**/docs/* \
+                         @SOURCE_DIR@/README.md
 EXCLUDE_SYMBOLS        = "std::*" \
                          "ROCPROFILER_ATTRIBUTE" \
                          "ROCPROFILER_API" \


### PR DESCRIPTION
# PR Details

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [* ] Documentation Update

## Technical details

_Please explain the changes along with JIRA/Github link(if applies).: Excluded the Readme.md file being inaccurately rendered in the documentation portal resulting in broken links in the page.
https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/_doxygen/html/md__2home_2docs_2checkouts_2readthedocs_8org_2user__builds_2advanced-micro-devices-rocprofiler-sd40c0902389b09edf3210254f2740a88.html
![image](https://github.com/user-attachments/assets/46d133c6-5c73-4d42-a292-677329848d3b)


## Added/updated tests?

_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ *] No, Does not apply to this PR.

## Updated CHANGELOG?

_Needed for Release updates for a ROCm release._

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.
