### PR TITLE
Add missing headers in tests and samples

### DIFF
--- a/samples/api_buffered_tracing/main.cpp
+++ b/samples/api_buffered_tracing/main.cpp
@@ -25,6 +25,8 @@
 #include "common/defines.hpp"
 #include "hip/hip_runtime.h"
 
+#include <libgen.h>
+
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -33,6 +35,7 @@
 #include <random>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 
 #define HIP_API_CALL(CALL)                                                                         \
     {                                                                                              \

--- a/samples/api_callback_tracing/main.cpp
+++ b/samples/api_callback_tracing/main.cpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <random>
 #include <stdexcept>
+#include <thread>
 
 #define HIP_API_CALL(CALL)                                                                         \
     {                                                                                              \

--- a/samples/code_object_isa_decode/main.cpp
+++ b/samples/code_object_isa_decode/main.cpp
@@ -22,10 +22,12 @@
 
 #include "hip/hip_runtime.h"
 
+#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <random>
 #include <stdexcept>

--- a/samples/code_object_tracing/main.cpp
+++ b/samples/code_object_tracing/main.cpp
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <random>
 #include <stdexcept>
+#include <thread>
 
 #define HIP_API_CALL(CALL)                                                                         \
     {                                                                                              \

--- a/samples/counter_collection/device_counting.cpp
+++ b/samples/counter_collection/device_counting.cpp
@@ -32,6 +32,7 @@
 #include <shared_mutex>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 

--- a/samples/counter_collection/main.cpp
+++ b/samples/counter_collection/main.cpp
@@ -24,6 +24,8 @@
 
 #include "client.hpp"
 
+#include <libgen.h>
+
 #define HIP_CALL(call)                                                                             \
     do                                                                                             \
     {                                                                                              \

--- a/samples/counter_collection/print_functional_counters.cpp
+++ b/samples/counter_collection/print_functional_counters.cpp
@@ -2,6 +2,7 @@
 
 #include <unistd.h>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>

--- a/samples/external_correlation_id_request/main.cpp
+++ b/samples/external_correlation_id_request/main.cpp
@@ -23,6 +23,8 @@
 #include "common/defines.hpp"
 #include "hip/hip_runtime.h"
 
+#include <libgen.h>
+
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -31,6 +33,7 @@
 #include <random>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 
 #define HIP_API_CALL(CALL)                                                                         \
     {                                                                                              \

--- a/samples/intercept_table/main.cpp
+++ b/samples/intercept_table/main.cpp
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <random>
 #include <stdexcept>
+#include <thread>
 
 #define HIP_API_CALL(CALL)                                                                         \
     {                                                                                              \

--- a/samples/pc_sampling/main.cpp
+++ b/samples/pc_sampling/main.cpp
@@ -23,6 +23,8 @@
 #include "common/defines.hpp"
 #include "hip/hip_runtime.h"
 
+#include <libgen.h>
+
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -31,6 +33,7 @@
 #include <random>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 
 #define HIP_API_CALL(CALL)                                                                         \
     {                                                                                              \

--- a/samples/pc_sampling/pcs.hpp
+++ b/samples/pc_sampling/pcs.hpp
@@ -25,6 +25,7 @@
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/rocprofiler.h>
 
+#include <memory>
 #include <vector>
 
 namespace client

--- a/tests/bin/hip-graph/hip-graph.cpp
+++ b/tests/bin/hip-graph/hip-graph.cpp
@@ -25,6 +25,8 @@ THE SOFTWARE.
 #include <iostream>
 #include <mutex>
 
+#include <libgen.h>
+
 // hip header file
 #include <hip/hip_runtime.h>
 

--- a/tests/bin/reproducible-runtime/reproducible-runtime.cpp
+++ b/tests/bin/reproducible-runtime/reproducible-runtime.cpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <random>
 #include <stdexcept>
+#include <thread>
 
 #if defined(USE_MPI)
 #    include <mpi.h>

--- a/tests/bin/transpose/transpose.cpp
+++ b/tests/bin/transpose/transpose.cpp
@@ -41,6 +41,7 @@
 #include <random>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 
 #define HIP_API_CALL(CALL)                                                                         \
     {                                                                                              \

--- a/tests/lib/transpose/transpose.cpp
+++ b/tests/lib/transpose/transpose.cpp
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <random>
 #include <stdexcept>
+#include <thread>
 
 #if defined(USE_MPI)
 #    include <mpi.h>

--- a/tests/lib/vector-operations/vector-ops.cpp
+++ b/tests/lib/vector-operations/vector-ops.cpp
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <mutex>
 #include <vector>
+#include <thread>
 
 #include "common/defines.hpp"
 

--- a/tests/thread-trace/main.cpp
+++ b/tests/thread-trace/main.cpp
@@ -25,6 +25,7 @@
 #    undef NDEBUG
 #endif
 
+#include <cassert>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>

--- a/tests/tools/c-tool.c
+++ b/tests/tools/c-tool.c
@@ -31,6 +31,8 @@
  * @brief Example rocprofiler client (tool) written in C
  */
 
+#include <stdio.h>
+
 #include <rocprofiler-sdk/registration.h>
 #include <rocprofiler-sdk/rocprofiler.h>
 


### PR DESCRIPTION
HIP is doing a header cleanup, some tests and samples were dependent on indirect inclusion of these headers. Include them manually.