### PR TITLE
otf2 output: Build up a proper system tree

### DIFF
--- a/source/lib/output/generateOTF2.cpp
+++ b/source/lib/output/generateOTF2.cpp
@@ -810,6 +810,9 @@ write_otf2(
     OTF2_CHECK(OTF2_GlobalDefWriter_WriteSystemTreeNode(
         global_def_writer, 0, _exe_hash, _node_hash, OTF2_UNDEFINED_SYSTEM_TREE_NODE));
 
+    OTF2_CHECK(OTF2_GlobalDefWriter_WriteSystemTreeNode(
+        global_def_writer, 0, OTF2_SYSTEM_TREE_DOMAIN_SHARED_MEMORY ));
+
     // Process
     OTF2_CHECK(OTF2_GlobalDefWriter_WriteLocationGroup(global_def_writer,
                                                        0,
@@ -825,12 +828,23 @@ write_otf2(
         auto        _hash = get_hash_id(_name);
 
         add_write_string(_hash, _name);
+
+        /* the device */
+        OTF2_CHECK(OTF2_GlobalDefWriter_WriteSystemTreeNode(
+            global_def_writer, agent_v.id.handle, _hash, 0, 0));
+
+        /* the device is an accelerator */
+        OTF2_CHECK(OTF2_GlobalDefWriter_WriteSystemTreeNode(
+            global_def_writer, agent_v.id.handle, OTF2_SYSTEM_TREE_DOMAIN_ACCELERATOR_DEVICE ));
+
+        /* the context */
         OTF2_CHECK(OTF2_GlobalDefWriter_WriteLocationGroup(global_def_writer,
                                                            agent_v.id.handle,
                                                            _hash,
                                                            OTF2_LOCATION_GROUP_TYPE_ACCELERATOR,
-                                                           0,
-                                                           OTF2_UNDEFINED_LOCATION_GROUP));
+                                                           agent_v.id.handle, // system tree node (aka the device)
+                                                           0                  // creating/controlling process
+                                                           ));
     }
 
     // Thread Events


### PR DESCRIPTION
OTF2 mandates that ACCELERATOR location groups need a ACCELERATOR_DEVICE system tree node as parent and that the creating location group is a PROCESS. The system tree node _class_ for the device should actually be something like "AMD GPU" and the _name_ be "{logical_node_type_id}" but uses currently only the same name as the location group for the _class_.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

Comply to the OTF2 event/metadata model.

## Added/updated tests?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.
