### PR TITLE
Extend the hack to propagate HIP usage requirements a bit further.

### DIFF
--- a/cmake/rocprofiler_config_interfaces.cmake
+++ b/cmake/rocprofiler_config_interfaces.cmake
@@ -127,7 +127,14 @@ find_package(
     ${rocm_version_DIR}
     ${ROCM_PATH})
 target_link_libraries(rocprofiler-sdk-hip INTERFACE hip::host)
+# TODO: As of 2024/2/12, the hip::host target does not advertise its
+# include directory but amdhip64 does. This ordinarily wouldn't be an issue
+# because most folks just get it transitively, but here this is doing direct
+# property copying to get usage requirements.
+# The proper fix is for hip to export a hip::headers target with only usage
+# requirements and depend on that.
 rocprofiler_config_nolink_target(rocprofiler-sdk-hip-nolink hip::host)
+rocprofiler_config_nolink_target(rocprofiler-sdk-hip-nolink hip::amdhip64)
 
 # ----------------------------------------------------------------------------------------#
 #
@@ -218,7 +225,9 @@ find_library(
     HINTS ${rocm_version_DIR} ${ROCM_PATH}
     PATHS ${rocm_version_DIR} ${ROCM_PATH})
 
-target_link_libraries(rocprofiler-sdk-hsa-aql INTERFACE ${hsa-amd-aqlprofile64_library})
+if(hsa-amd-aqlprofile64_library)
+    target_link_libraries(rocprofiler-sdk-hsa-aql INTERFACE ${hsa-amd-aqlprofile64_library})
+endif()
 
 # ----------------------------------------------------------------------------------------#
 #

--- a/source/lib/common/container/CMakeLists.txt
+++ b/source/lib/common/container/CMakeLists.txt
@@ -9,3 +9,4 @@ set(containers_sources ring_buffer.cpp record_header_buffer.cpp ring_buffer.cpp
 
 target_sources(rocprofiler-sdk-common-library PRIVATE ${containers_sources}
                                                       ${containers_headers})
+target_link_libraries(rocprofiler-sdk-common-library PRIVATE rocprofiler-sdk-hip-nolink)

--- a/source/lib/output/CMakeLists.txt
+++ b/source/lib/output/CMakeLists.txt
@@ -60,4 +60,5 @@ target_link_libraries(
             rocprofiler-sdk::rocprofiler-sdk-common-library
             rocprofiler-sdk::rocprofiler-sdk-cereal
             rocprofiler-sdk::rocprofiler-sdk-perfetto
-            rocprofiler-sdk::rocprofiler-sdk-otf2)
+            rocprofiler-sdk::rocprofiler-sdk-otf2
+            rocprofiler-sdk-hip-nolink)


### PR DESCRIPTION
* Also fetches usage requirements from hip::amdhip64 -> rocprofiler-sdk-hip-nolink
* Adds rocprofiler-sdk-hip-nolink as a dependency of two libraries that indirectly depend on hip headers via hip.h.
* The above may not be completely as precise as it can be (it seems like there should be an intermediate library for this of some kind).
* Also conditions the link of hsa-amd-aqlprofile64_library on whether the library was found. I have no idea if this is correct, but I don't have that library and lack an easy way to get it. Since the find_library can fail, I am left assuming it is optional (otherwise, there should be some error reporting). The resulting libraries seem to have all symbols defined.

