### PR TITLE
Extend the hack to propagate HIP usage requirements a bit further.

### DIFF
--- a/cmake/rocprofiler_config_interfaces.cmake
+++ b/cmake/rocprofiler_config_interfaces.cmake
@@ -127,7 +127,14 @@ find_package(
     ${rocm_version_DIR}
     ${ROCM_PATH})
 target_link_libraries(rocprofiler-sdk-hip INTERFACE hip::host)
+# TODO: As of 2024/2/12, the hip::host target does not advertise its
+# include directory but amdhip64 does. This ordinarily wouldn't be an issue
+# because most folks just get it transitively, but here this is doing direct
+# property copying to get usage requirements.
+# The proper fix is for hip to export a hip::headers target with only usage
+# requirements and depend on that.
 rocprofiler_config_nolink_target(rocprofiler-sdk-hip-nolink hip::host)
+rocprofiler_config_nolink_target(rocprofiler-sdk-hip-nolink hip::amdhip64)
 
 # ----------------------------------------------------------------------------------------#
 #
@@ -218,7 +225,9 @@ find_library(
     HINTS ${rocm_version_DIR} ${ROCM_PATH}
     PATHS ${rocm_version_DIR} ${ROCM_PATH})
 
-target_link_libraries(rocprofiler-sdk-hsa-aql INTERFACE ${hsa-amd-aqlprofile64_library})
+if(hsa-amd-aqlprofile64_library)
+    target_link_libraries(rocprofiler-sdk-hsa-aql INTERFACE ${hsa-amd-aqlprofile64_library})
+endif()
 
 # ----------------------------------------------------------------------------------------#
 #

--- a/source/lib/common/container/CMakeLists.txt
+++ b/source/lib/common/container/CMakeLists.txt
@@ -9,3 +9,4 @@ set(containers_sources ring_buffer.cpp record_header_buffer.cpp ring_buffer.cpp
 
 target_sources(rocprofiler-sdk-common-library PRIVATE ${containers_sources}
                                                       ${containers_headers})
+target_link_libraries(rocprofiler-sdk-common-library PRIVATE rocprofiler-sdk-hip-nolink)

--- a/source/lib/output/CMakeLists.txt
+++ b/source/lib/output/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(
             rocprofiler-sdk::rocprofiler-sdk-cereal
             rocprofiler-sdk::rocprofiler-sdk-perfetto
             rocprofiler-sdk::rocprofiler-sdk-otf2
+	    rocprofiler-sdk-hip-nolink
             rocprofiler-sdk::rocprofiler-sdk-amd-comgr
             rocprofiler-sdk::rocprofiler-sdk-dw
             rocprofiler-sdk::rocprofiler-sdk-elf)


### PR DESCRIPTION
# PR Details

## Associated Jira Ticket Number/Link
Patch coming from TheRock: https://github.com/ROCm/TheRock/issues/302

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

- Also fetches usage requirements from hip::amdhip64 -> rocprofiler-sdk-hip-nolink
- Adds rocprofiler-sdk-hip-nolink as a dependency of two libraries that indirectly depend on hip headers via hip.h.
- The above may not be completely as precise as it can be (it seems like there should be an intermediate library for this of some kind).
- Also conditions the link of hsa-amd-aqlprofile64_library on whether the library was found, which however might not be correct.

## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.
