### PR TITLE
Update grid_size output to follow HIP definition

### DIFF
--- a/source/lib/output/generateRocpd.cpp
+++ b/source/lib/output/generateRocpd.cpp
@@ -988,6 +988,11 @@ write_rocpd(
                 auto corr_id     = itr.correlation_id;
                 auto grid        = info.grid_size;
                 auto workgroup   = info.workgroup_size;
+                auto hip_grid    = decltype(grid){
+                    .x = grid.x / workgroup.x,
+                    .y = grid.y / workgroup.y,
+                    .z = grid.z / workgroup.z,
+                };
                 auto kern_name = tool_metadata.get_kernel_symbol(kernel_id)->formatted_kernel_name;
                 auto stream_id = get_stream_id(itr.stream_id);
                 auto queue_id  = get_queue_id(info.queue_id);
@@ -1038,9 +1043,9 @@ write_rocpd(
                         insert_value("workgroup_size_x", workgroup.x),
                         insert_value("workgroup_size_y", workgroup.y),
                         insert_value("workgroup_size_z", workgroup.z),
-                        insert_value("grid_size_x", grid.x),
-                        insert_value("grid_size_y", grid.y),
-                        insert_value("grid_size_z", grid.z),
+                        insert_value("grid_size_x", hip_grid.x),
+                        insert_value("grid_size_y", hip_grid.y),
+                        insert_value("grid_size_z", hip_grid.z),
                         insert_value("region_name_id", string_entries.at(region_name)),
                         insert_value("event_id", evt_id),
                     });


### PR DESCRIPTION
# PR Details

## Associated Jira Ticket Number/Link

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

Current Grid_Size output is not aligned with HIP/rocprofv3 definition. It currently outputs total number of threads which is  (Grid Size in HIP * Block Size in HIP). 

Dividing the total number of threads by Block Size in HIP (which is equivalent to Workgroup Size) will equal Grid Size in HIP.

## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [X] No, Does not apply to this PR.
