### PR TITLE
Add Google logging initializer to OMPT start tool to prevent benign warning.

### DIFF
--- a/source/lib/rocprofiler-sdk/ompt.cpp
+++ b/source/lib/rocprofiler-sdk/ompt.cpp
@@ -245,6 +245,7 @@ ompt_start_tool(unsigned int omp_version, const char* runtime_version) ROCPROFIL
 ompt_start_tool_result_t*
 ompt_start_tool(unsigned int omp_version, const char* runtime_version)
 {
+    ::rocprofiler::registration::init_logging();
     ::rocprofiler::registration::initialize();
     return rocprofiler_ompt_start_tool(omp_version, runtime_version);
 }

--- a/source/lib/rocprofiler-sdk/registration.cpp
+++ b/source/lib/rocprofiler-sdk/registration.cpp
@@ -670,6 +670,8 @@ set_fini_status(int v)
 void
 initialize()
 {
+    init_logging();
+    
     ROCP_INFO << "rocprofiler initialize called...";
 
     if(get_init_status() != 0)
@@ -688,7 +690,6 @@ initialize()
             common::destroy_static_tl_objects();
             common::destroy_static_objects();
         });
-        init_logging();
         invoke_client_configures();
         invoke_client_initializers();
         if(get_num_clients() > 0) internal_threading::initialize();


### PR DESCRIPTION
# PR Details

## Associated Jira Ticket Number/Link
Resolves #63

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

Benign warning `WARNING: Logging before InitGoogleLogging() is written to STDERR` occurs because `registration::initialize()` was called without `registration::init_logging` having been called before `ROCP_INFO`s were emitted.

Added `registration::init_logging` call inside `ompt_start_tool`, the only observable codepath which did not first initialize logging, and moved the call further up in `registration::initialize` to prevent similar cases in the future.

## Added/updated tests?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.
