### PR TITLE
  CI: Restrict workflow execution to primary branches only

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -52,7 +52,8 @@ env:
 
 jobs:
   code-coverage:
-    if: ${{ contains(github.event_name, 'pull_request') }}
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(github.event_name, 'pull_request') && (contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref)) }}
     strategy:
       # fail-fast: false
       matrix:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -48,6 +48,8 @@ env:
 
 jobs:
   core-deb:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
       fail-fast: false
@@ -180,6 +182,8 @@ jobs:
           ${{github.workspace}}/build/*.tgz
 
   core-rpm:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
       fail-fast: false
@@ -259,6 +263,8 @@ jobs:
           -E "${${{ matrix.runner }}_EXCLUDE_TESTS_REGEX}"
 
   sanitizers:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(github.event_name, 'pull_request') && (contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref)) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,8 @@ env:
 
 jobs:
   build-docs:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     runs-on: AMD-ROCm-Internal-dev1
     container: continuumio/miniconda3
     permissions:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -17,6 +17,8 @@ concurrency:
 
 jobs:
   cmake:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     runs-on: AMD-ROCm-Internal-dev1
     env:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,6 +52,8 @@ jobs:
         fi
 
   source:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     runs-on: AMD-ROCm-Internal-dev1
     container: rocm/dev-ubuntu-22.04:latest
     env:
@@ -86,6 +90,8 @@ jobs:
         fi
 
   python:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     runs-on: AMD-ROCm-Internal-dev1
     strategy:
       matrix:
@@ -125,6 +131,8 @@ jobs:
         fi
 
   missing-new-line:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     runs-on: AMD-ROCm-Internal-dev1
 
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,6 +16,8 @@ concurrency:
 
 jobs:
   linting:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     runs-on: AMD-ROCm-Internal-dev1
     strategy:
       matrix:

--- a/.github/workflows/restrictions.yml
+++ b/.github/workflows/restrictions.yml
@@ -27,6 +27,8 @@ concurrency:
 
 jobs:
   regex:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     runs-on: AMD-ROCm-Internal-dev1
     env:
       FOLDERS: "source/lib/common source/lib/rocprofiler-sdk source/lib/rocprofiler-sdk-roctx"

--- a/.github/workflows/rocm_release_compatibility.yml
+++ b/.github/workflows/rocm_release_compatibility.yml
@@ -27,6 +27,8 @@ env:
 
 jobs:
   rocm-release-compatibility:
+    # Only run this job when targeting amd-staging, amd-mainline, or amd-npi branches
+    if: ${{ contains(fromJSON('["amd-staging", "amd-mainline", "amd-npi"]'), github.base_ref) || contains(fromJSON('["refs/heads/amd-staging", "refs/heads/amd-mainline", "refs/heads/amd-npi"]'), github.ref) }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
  Updated GitHub Actions workflows to only run CI checks when targeting
  amd-staging, amd-mainline, or amd-npi branches. This prevents unnecessary
  CI runs on feature branches and release branches.

  Modified workflows:
  - continuous_integration.yml: core-deb, core-rpm, sanitizers jobs
  - code_coverage.yml: code-coverage job
  - rocm_release_compatibility.yml: rocm-release-compatibility job
  - formatting.yml: cmake, source, python, missing-new-line jobs
  - python.yml: linting job
  - restrictions.yml: regex job

  All jobs now check if github.base_ref (for PRs) or github.ref (for pushes)
  matches one of the allowed primary branches before executing.


# PR Details

## Associated Jira Ticket Number/Link

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

<!-- Please explain the changes along with JIRA/Github link(if applies). -->

## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.
