### PR TITLE
Remove calls to find_package(hsakmt) as it is being removed from ROCr.

### DIFF
--- a/cmake/rocprofiler_config_interfaces.cmake
+++ b/cmake/rocprofiler_config_interfaces.cmake
@@ -226,28 +226,6 @@ target_link_libraries(rocprofiler-sdk-hsa-aql INTERFACE ${hsa-amd-aqlprofile64_l
 
 # ----------------------------------------------------------------------------------------#
 #
-# HSAKMT
-#
-# ----------------------------------------------------------------------------------------#
-
-find_package(
-    hsakmt
-    REQUIRED
-    CONFIG
-    HINTS
-    ${rocm_version_DIR}
-    ${ROCM_PATH}
-    PATHS
-    ${rocm_version_DIR}
-    ${ROCM_PATH}
-    PATH_SUFFIXES
-    lib/cmake/hsakmt)
-
-target_link_libraries(rocprofiler-sdk-hsakmt INTERFACE hsakmt::hsakmt)
-rocprofiler_config_nolink_target(rocprofiler-sdk-hsakmt-nolink hsakmt::hsakmt)
-
-# ----------------------------------------------------------------------------------------#
-#
 # drm
 #
 # ----------------------------------------------------------------------------------------#


### PR DESCRIPTION
    Removed the static version of the HSAKMT library (libhsakmt.a)
    from the shared release packages because, there were some missing
    exported symbols.  This library was only meant to be used
    internally and therefore should not be included in any public
    releases.


# PR Details

## Associated Jira Ticket Number/Link
https://ontrack-internal.amd.com/browse/SWDEV-529641?filter=-1
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

<!-- Please explain the changes along with JIRA/Github link(if applies). -->
This is related to PR: https://github.com/AMD-ROCm-Internal/ROCR-Runtime/pull/169
## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.
