### PR TITLE
Add debug formatting support for HSA queue management classes

### DIFF
--- a/source/lib/rocprofiler-sdk/hsa/hsa_barrier.cpp
+++ b/source/lib/rocprofiler-sdk/hsa/hsa_barrier.cpp
@@ -25,6 +25,7 @@
 #include "lib/rocprofiler-sdk/registration.hpp"
 
 #include <functional>
+#include <sstream>
 
 namespace rocprofiler
 {
@@ -159,6 +160,46 @@ hsa_barrier::clear_barrier()
     }
     _core_api.hsa_signal_store_screlease_fn(_barrier_signal, 0);
     ROCP_TRACE << "Barrier (handle: " << _barrier_signal.handle << ") is now cleared.";
+}
+
+std::string
+hsa_barrier::to_string() const
+{
+    std::ostringstream oss;
+    oss << "hsa_barrier{";
+    
+    // _barrier_finished (function pointer - just indicate if it's set)
+    oss << "_barrier_finished: " << (_barrier_finished ? "set" : "null") << ", ";
+    
+    // _barrier_signal
+    oss << "_barrier_signal: {handle: " << _barrier_signal.handle << "}, ";
+    
+    // _queue_waiting
+    oss << "_queue_waiting: {";
+    _queue_waiting.rlock([&](const auto& queue_waiting) {
+        bool first = true;
+        for(const auto& [queue_id, count] : queue_waiting) {
+            if(!first) oss << ", ";
+            oss << queue_id << ": " << count;
+            first = false;
+        }
+    });
+    oss << "}, ";
+    
+    // _barrier_enqueued
+    oss << "_barrier_enqueued: {";
+    _barrier_enqueued.rlock([&](const auto& barrier_enqueued) {
+        bool first = true;
+        for(const auto& queue_id : barrier_enqueued) {
+            if(!first) oss << ", ";
+            oss << queue_id;
+            first = false;
+        }
+    });
+    oss << "}";
+    
+    oss << "}";
+    return oss.str();
 }
 
 }  // namespace hsa

--- a/source/lib/rocprofiler-sdk/hsa/hsa_barrier.cpp
+++ b/source/lib/rocprofiler-sdk/hsa/hsa_barrier.cpp
@@ -167,37 +167,39 @@ hsa_barrier::to_string() const
 {
     std::ostringstream oss;
     oss << "hsa_barrier{";
-    
+
     // _barrier_finished (function pointer - just indicate if it's set)
     oss << "_barrier_finished: " << (_barrier_finished ? "set" : "null") << ", ";
-    
+
     // _barrier_signal
     oss << "_barrier_signal: {handle: " << _barrier_signal.handle << "}, ";
-    
+
     // _queue_waiting
     oss << "_queue_waiting: {";
     _queue_waiting.rlock([&](const auto& queue_waiting) {
         bool first = true;
-        for(const auto& [queue_id, count] : queue_waiting) {
+        for(const auto& [queue_id, count] : queue_waiting)
+        {
             if(!first) oss << ", ";
             oss << queue_id << ": " << count;
             first = false;
         }
     });
     oss << "}, ";
-    
+
     // _barrier_enqueued
     oss << "_barrier_enqueued: {";
     _barrier_enqueued.rlock([&](const auto& barrier_enqueued) {
         bool first = true;
-        for(const auto& queue_id : barrier_enqueued) {
+        for(const auto& queue_id : barrier_enqueued)
+        {
             if(!first) oss << ", ";
             oss << queue_id;
             first = false;
         }
     });
     oss << "}";
-    
+
     oss << "}";
     return oss.str();
 }

--- a/source/lib/rocprofiler-sdk/hsa/hsa_barrier.hpp
+++ b/source/lib/rocprofiler-sdk/hsa/hsa_barrier.hpp
@@ -31,9 +31,12 @@
 #include <hsa/hsa_api_trace.h>
 #include <hsa/hsa_ext_amd.h>
 
+#include <fmt/format.h>
+
 #include <atomic>
 #include <functional>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -72,6 +75,9 @@ public:
     // If this is the last queue waiting, clears the barrier and marks it as complete.
     void remove_queue(const Queue* queue);
 
+    // Returns a string containing all class variable data
+    std::string to_string() const;
+
 private:
     std::function<void()>                                      _barrier_finished = {};
     CoreApiTable                                               _core_api         = {};
@@ -86,3 +92,23 @@ private:
 
 }  // namespace hsa
 }  // namespace rocprofiler
+
+namespace fmt
+{
+// fmt::format support for hsa_barrier
+template <>
+struct formatter<rocprofiler::hsa::hsa_barrier>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename Ctx>
+    auto format(rocprofiler::hsa::hsa_barrier const& barrier, Ctx& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{}", barrier.to_string());
+    }
+};
+}  // namespace fmt

--- a/source/lib/rocprofiler-sdk/hsa/profile_serializer.cpp
+++ b/source/lib/rocprofiler-sdk/hsa/profile_serializer.cpp
@@ -150,7 +150,6 @@ profiler_serializer::queue_ready(hsa_queue_t* hsa_queue, const Queue& queue)
         ->get_core_table()
         .hsa_signal_store_screlease_fn(queue.ready_signal, 1);
 
-
     if(_dispatch_queue == nullptr)
     {
         CHECK_NOTNULL(get_queue_controller())
@@ -293,23 +292,28 @@ profiler_serializer::to_string() const
 {
     std::ostringstream oss;
     oss << "profiler_serializer{";
-    
+
     // _dispatch_queue
     oss << "_dispatch_queue: ";
-    if(_dispatch_queue) {
+    if(_dispatch_queue)
+    {
         oss << "{id: " << _dispatch_queue->get_id().handle << "}";
-    } else {
+    }
+    else
+    {
         oss << "null";
     }
     oss << ", ";
-    
+
     // _dispatch_ready
     oss << "_dispatch_ready: {";
     oss << "count: " << _dispatch_ready.size();
-    if(!_dispatch_ready.empty()) {
+    if(!_dispatch_ready.empty())
+    {
         oss << ", queue_ids: [";
         bool first = true;
-        for(const auto* queue : _dispatch_ready) {
+        for(const auto* queue : _dispatch_ready)
+        {
             if(!first) oss << ", ";
             oss << (queue ? queue->get_id().handle : 0);
             first = false;
@@ -317,26 +321,30 @@ profiler_serializer::to_string() const
         oss << "]";
     }
     oss << "}, ";
-    
+
     // _serializer_status
     oss << "_serializer_status: ";
-    switch(_serializer_status.load()) {
+    switch(_serializer_status.load())
+    {
         case Status::ENABLED: oss << "ENABLED"; break;
         case Status::DISABLED: oss << "DISABLED"; break;
         default: oss << "UNKNOWN"; break;
     }
     oss << ", ";
-    
+
     // _barrier
     oss << "_barrier: {";
     oss << "count: " << _barrier.size();
-    if(!_barrier.empty()) {
+    if(!_barrier.empty())
+    {
         oss << ", barriers: [";
         bool first = true;
-        for(const auto& barrier : _barrier) {
+        for(const auto& barrier : _barrier)
+        {
             if(!first) oss << ", ";
             oss << "{state: ";
-            switch(barrier.state) {
+            switch(barrier.state)
+            {
                 case Status::ENABLED: oss << "ENABLED"; break;
                 case Status::DISABLED: oss << "DISABLED"; break;
                 default: oss << "UNKNOWN"; break;

--- a/source/lib/rocprofiler-sdk/hsa/profile_serializer.hpp
+++ b/source/lib/rocprofiler-sdk/hsa/profile_serializer.hpp
@@ -95,8 +95,8 @@ private:
     std::deque<const Queue*>       _dispatch_ready;
     std::atomic<Status>            _serializer_status{Status::DISABLED};
     std::deque<barrier_with_state> _barrier;
-    mutable std::atomic<int64_t> _enqueued_packets{0};
-    mutable std::atomic<int64_t> _completed_packets{0};
+    mutable std::atomic<int64_t>   _enqueued_packets{0};
+    mutable std::atomic<int64_t>   _completed_packets{0};
 };
 
 }  // namespace hsa

--- a/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -676,42 +676,44 @@ Queue::to_string() const
 {
     std::ostringstream oss;
     oss << "Queue{";
-    
+
     // _notifiers
     oss << "_notifiers: " << _notifiers.load() << ", ";
 
     // _active_async_packets
     oss << "_active_async_packets: " << _active_async_packets.load() << ", ";
-    
+
     // _callbacks (show count)
     oss << "_callbacks: {";
-    _callbacks.rlock([&](const auto& callbacks) {
-        oss << "count: " << callbacks.size();
-    });
+    _callbacks.rlock([&](const auto& callbacks) { oss << "count: " << callbacks.size(); });
     oss << "}, ";
-    
+
     // _intercept_queue (show ID if not null)
     oss << "_intercept_queue: ";
-    if(_intercept_queue) {
+    if(_intercept_queue)
+    {
         oss << "{id: " << _intercept_queue->id << "}";
-    } else {
+    }
+    else
+    {
         oss << "null";
     }
     oss << ", ";
-    
+
     // _state
     oss << "_state: ";
-    switch(_state) {
+    switch(_state)
+    {
         case queue_state::normal: oss << "normal"; break;
         case queue_state::to_destroy: oss << "to_destroy"; break;
         case queue_state::done_destroy: oss << "done_destroy"; break;
         default: oss << "unknown"; break;
     }
     oss << ", ";
-    
+
     // _active_kernels signal
     oss << "_active_kernels: {handle: " << _active_kernels.handle << "}, ";
-    
+
     // block_signal and ready_signal
     oss << "block_signal: {handle: " << block_signal.handle << "}, ";
     oss << "ready_signal: {handle: " << ready_signal.handle << "}";

--- a/source/lib/rocprofiler-sdk/hsa/queue.hpp
+++ b/source/lib/rocprofiler-sdk/hsa/queue.hpp
@@ -42,10 +42,13 @@
 #include <hsa/hsa_ven_amd_aqlprofile.h>
 #include <hsa/hsa_ven_amd_loader.h>
 
+#include <fmt/format.h>
+
 #include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 namespace rocprofiler
@@ -151,6 +154,9 @@ public:
     queue_state                     get_state() const;
     void                            set_state(queue_state state);
 
+    // Returns a string containing all class variable data
+    std::string to_string() const;
+
 private:
     std::atomic<int>                     _notifiers            = {0};
     std::atomic<int64_t>                 _active_async_packets = {0};
@@ -186,3 +192,23 @@ Queue::lock_queue(FuncT&& func)
 }
 }  // namespace hsa
 }  // namespace rocprofiler
+
+namespace fmt
+{
+// fmt::format support for Queue
+template <>
+struct formatter<rocprofiler::hsa::Queue>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename Ctx>
+    auto format(rocprofiler::hsa::Queue const& queue, Ctx& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{}", queue.to_string());
+    }
+};
+}  // namespace fmt

--- a/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -435,38 +435,41 @@ QueueController::to_string() const
 {
     std::ostringstream oss;
     oss << "QueueController{";
-    
+
     // _queues (show count)
     oss << "_queues: {";
     _queues.rlock([&](const auto& queues) {
         oss << "count: " << queues.size();
-        if(!queues.empty()) {
+        if(!queues.empty())
+        {
             oss << ", queue_ids: [";
             bool first = true;
-            for(const auto& [hsa_queue, queue_ptr] : queues) {
+            for(const auto& [hsa_queue, queue_ptr] : queues)
+            {
                 if(!first) oss << ", ";
-                oss << "[" << (hsa_queue ? hsa_queue->id : 0) << fmt::format(",{}", *queue_ptr) << "]";
+                oss << "[" << (hsa_queue ? hsa_queue->id : 0) << fmt::format(",{}", *queue_ptr)
+                    << "]";
                 first = false;
             }
             oss << "]";
         }
     });
     oss << "}, ";
-    
+
     // _callback_cache (show count)
     oss << "_callback_cache: {";
-    _callback_cache.rlock([&](const auto& callbacks) {
-        oss << "count: " << callbacks.size();
-    });
+    _callback_cache.rlock([&](const auto& callbacks) { oss << "count: " << callbacks.size(); });
     oss << "}, ";
-    
+
     // _supported_agents (show count and node_ids)
     oss << "_supported_agents: {";
     oss << "count: " << _supported_agents.size();
-    if(!_supported_agents.empty()) {
+    if(!_supported_agents.empty())
+    {
         oss << ", node_ids: [";
         bool first = true;
-        for(const auto& [node_id, agent_cache] : _supported_agents) {
+        for(const auto& [node_id, agent_cache] : _supported_agents)
+        {
             if(!first) oss << ", ";
             oss << node_id;
             first = false;
@@ -474,31 +477,29 @@ QueueController::to_string() const
         oss << "]";
     }
     oss << "}, ";
-    
+
     // _serialized_enabled
     oss << "_serialized_enabled: " << (_serialized_enabled.load() ? "true" : "false") << ", ";
-    
+
     // _profiler_serializer (show count)
     oss << "_profiler_serializer: {";
     _profiler_serializer.rlock([&](const auto& serializers) {
-        for (const auto& [id, serializer] : serializers) {
-            auto serializer_data =  serializer->rlock([](const auto& s) {
-                return s.to_string();
-            });
+        for(const auto& [id, serializer] : serializers)
+        {
+            auto serializer_data = serializer->rlock([](const auto& s) { return s.to_string(); });
             oss << "[" << id.handle << ": " << serializer_data << "]";
         }
     });
     oss << "}";
-    
+
 #if !defined(NDEBUG)
     // _debug_signals (show count if in debug mode)
     oss << ", _debug_signals: {";
-    _debug_signals.rlock([&](const auto& debug_signals) {
-        oss << "count: " << debug_signals.size();
-    });
+    _debug_signals.rlock(
+        [&](const auto& debug_signals) { oss << "count: " << debug_signals.size(); });
     oss << "}";
 #endif
-    
+
     oss << "}";
     return oss.str();
 }

--- a/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+#include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
@@ -29,6 +30,7 @@
 
 #include <rocprofiler-sdk/fwd.h>
 #include <memory>
+#include <sstream>
 
 namespace rocprofiler
 {
@@ -428,6 +430,79 @@ QueueController::get_supported_agents()
     return _supported_agents;
 }
 
+std::string
+QueueController::to_string() const
+{
+    std::ostringstream oss;
+    oss << "QueueController{";
+    
+    // _queues (show count)
+    oss << "_queues: {";
+    _queues.rlock([&](const auto& queues) {
+        oss << "count: " << queues.size();
+        if(!queues.empty()) {
+            oss << ", queue_ids: [";
+            bool first = true;
+            for(const auto& [hsa_queue, queue_ptr] : queues) {
+                if(!first) oss << ", ";
+                oss << "[" << (hsa_queue ? hsa_queue->id : 0) << fmt::format(",{}", *queue_ptr) << "]";
+                first = false;
+            }
+            oss << "]";
+        }
+    });
+    oss << "}, ";
+    
+    // _callback_cache (show count)
+    oss << "_callback_cache: {";
+    _callback_cache.rlock([&](const auto& callbacks) {
+        oss << "count: " << callbacks.size();
+    });
+    oss << "}, ";
+    
+    // _supported_agents (show count and node_ids)
+    oss << "_supported_agents: {";
+    oss << "count: " << _supported_agents.size();
+    if(!_supported_agents.empty()) {
+        oss << ", node_ids: [";
+        bool first = true;
+        for(const auto& [node_id, agent_cache] : _supported_agents) {
+            if(!first) oss << ", ";
+            oss << node_id;
+            first = false;
+        }
+        oss << "]";
+    }
+    oss << "}, ";
+    
+    // _serialized_enabled
+    oss << "_serialized_enabled: " << (_serialized_enabled.load() ? "true" : "false") << ", ";
+    
+    // _profiler_serializer (show count)
+    oss << "_profiler_serializer: {";
+    _profiler_serializer.rlock([&](const auto& serializers) {
+        for (const auto& [id, serializer] : serializers) {
+            auto serializer_data =  serializer->rlock([](const auto& s) {
+                return s.to_string();
+            });
+            oss << "[" << id.handle << ": " << serializer_data << "]";
+        }
+    });
+    oss << "}";
+    
+#if !defined(NDEBUG)
+    // _debug_signals (show count if in debug mode)
+    oss << ", _debug_signals: {";
+    _debug_signals.rlock([&](const auto& debug_signals) {
+        oss << "count: " << debug_signals.size();
+    });
+    oss << "}";
+#endif
+    
+    oss << "}";
+    return oss.str();
+}
+
 QueueController*
 get_queue_controller()
 {
@@ -482,3 +557,17 @@ queue_controller_fini()
 }
 }  // namespace hsa
 }  // namespace rocprofiler
+
+extern "C" void
+rocprofiler_debug_print_queue_controller_state()
+{
+    auto* controller = rocprofiler::hsa::get_queue_controller();
+    if(controller)
+    {
+        ROCP_ERROR << "QueueController Debug State: " << controller->to_string();
+    }
+    else
+    {
+        ROCP_ERROR << "QueueController Debug State: controller is null";
+    }
+}

--- a/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -151,7 +151,8 @@ extern "C" {
 #endif
 
 // Debug function to print QueueController state to ROCP_ERROR log
-void rocprofiler_debug_print_queue_controller_state();
+void
+rocprofiler_debug_print_queue_controller_state();
 
 #ifdef __cplusplus
 }

--- a/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -28,9 +28,12 @@
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/cxx/hash.hpp>
 
+#include <fmt/format.h>
+
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -98,6 +101,9 @@ public:
     // serialization related signals if not compiled in debug mode.
     void print_debug_signals() const;
 
+    // Returns a string containing all class variable data
+    std::string to_string() const;
+
 #if !defined(NDEBUG)
     // Tracks the creation of all signals in queues, used for debugging and disabled
     // in release mode (adds locking around signal creation).
@@ -139,3 +145,34 @@ void
 profiler_serializer_kernel_completion_signal(hsa_signal_t queue_block_signal);
 }  // namespace hsa
 }  // namespace rocprofiler
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Debug function to print QueueController state to ROCP_ERROR log
+void rocprofiler_debug_print_queue_controller_state();
+
+#ifdef __cplusplus
+}
+#endif
+
+namespace fmt
+{
+// fmt::format support for QueueController
+template <>
+struct formatter<rocprofiler::hsa::QueueController>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename Ctx>
+    auto format(rocprofiler::hsa::QueueController const& controller, Ctx& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{}", controller.to_string());
+    }
+};
+}  // namespace fmt


### PR DESCRIPTION
- Add `to_string()` methods and `fmt` formatters for
  `hsa_barrier`, `Queue`, `QueueController`, and `profiler_serializer` classes.
- Include comprehensive state information for debugging queue serialization and kernel dispatch issues.
- Add C exported function
  `rocprofiler_debug_print_queue_controller_state()`
  for runtime debugging via `ROCP_ERROR` logging.
- Thread-safe access to synchronized containers using `rlock()`.
- Exclude API table objects from debug output as requested.
- Support conditional compilation for debug-only fields.

The debug output includes queue states, signal handles, callback counts, agent information, and serialization status to aid in diagnosing deadlocks and race conditions in the profiler serialization system.


# PR Details

## Associated Jira Ticket Number/Link

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

<!-- Please explain the changes along with JIRA/Github link(if applies). -->

## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.
