### PR TITLE
Fix rocpd memory allocation trace csv output

### DIFF
--- a/source/lib/python/rocpd/source/csv.cpp
+++ b/source/lib/python/rocpd/source/csv.cpp
@@ -318,7 +318,13 @@ write_memory_allocation_csv(
         CsvType::MEMORY_ALLOCATION,
         memory_alloc_gen,
         [](CsvManager& cm, CsvType type, const rocpd::types::memory_allocation& malloc) {
-            std::string operation = fmt::format("MEMORY_ALLOCATION_{}", malloc.type);
+            std::string normalized_type = malloc.type;
+            if (normalized_type == "ALLOC")
+            {
+                normalized_type = "ALLOCATE";
+            }
+
+            std::string operation = fmt::format("MEMORY_ALLOCATION_{}", normalized_type);
 
             std::string agent_identifier = create_agent_index(cm.config.agent_index_value,
                                                               malloc.agent_abs_index,


### PR DESCRIPTION
# PR Details
This PR fixes the csv output for memory allocation trace generated by rocpd 

## Associated Jira Ticket Number/Link
https://ontrack-internal.amd.com/browse/SWDEV-539980

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

<!-- Please explain the changes along with JIRA/Github link(if applies). -->

## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.
