### PR TITLE
Always enable PC sampling tests in CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -90,7 +90,6 @@ jobs:
         ls -la
 
     - name: Enable PC Sampling
-      if: ${{ contains(matrix.runner, 'mi200') || contains(matrix.runner, 'mi300a') }}
       shell: bash
       run: |
           echo 'ROCPROFILER_PC_SAMPLING_BETA_ENABLED=1' >> $GITHUB_ENV
@@ -224,7 +223,6 @@ jobs:
         ls -la
 
     - name: Enable PC Sampling
-      if: ${{ contains(matrix.runner, 'mi200') || contains(matrix.runner, 'mi300a') }}
       shell: bash
       run: |
           echo 'ROCPROFILER_PC_SAMPLING_BETA_ENABLED=1' >> $GITHUB_ENV
@@ -295,7 +293,6 @@ jobs:
         ls -la
 
     - name: Enable PC Sampling
-      if: ${{ contains(matrix.runner, 'mi200') || contains(matrix.runner, 'mi300a') }}
       shell: bash
       run: |
           echo 'ROCPROFILER_PC_SAMPLING_BETA_ENABLED=1' >> $GITHUB_ENV

--- a/samples/pc_sampling/CMakeLists.txt
+++ b/samples/pc_sampling/CMakeLists.txt
@@ -50,6 +50,15 @@ rocprofiler_samples_get_ld_library_path_env(LIBRARY_PATH_ENV)
 # Check if PC sampling is disabled and whether we should disable the test
 rocprofiler_sdk_pc_sampling_disabled(IS_PC_SAMPLING_DISABLED)
 
+# For some reason, ThreadSanitizer reports a lock-order-invervsion error when running the
+# transpose application standalone. Thus, we disable ThreadSanitizer on PC sampling tests
+# that are using transpose application.
+if(IS_PC_SAMPLING_DISABLED OR ROCPROFILER_MEMCHECK STREQUAL "ThreadSanitizer")
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
 set(pc-sampling-env ${PRELOAD_ENV} ${LIBRARY_PATH_ENV})
 
 add_test(NAME pc-sampling COMMAND $<TARGET_FILE:pc-sampling>)
@@ -67,4 +76,4 @@ set_tests_properties(
                SKIP_REGULAR_EXPRESSION
                "PC sampling unavailable"
                DISABLED
-               "${IS_PC_SAMPLING_DISABLED}")
+               "${IS_DISABLED}")

--- a/tests/rocprofv3/pc-sampling/host-trap/transpose-multiple-agents/CMakeLists.txt
+++ b/tests/rocprofv3/pc-sampling/host-trap/transpose-multiple-agents/CMakeLists.txt
@@ -13,6 +13,15 @@ find_package(rocprofiler-sdk REQUIRED)
 # Check if PC sampling is disabled and whether we should skip the tests.
 rocprofiler_sdk_pc_sampling_disabled(IS_PC_SAMPLING_DISABLED)
 
+# For some reason, ThreadSanitizer reports a lock-order-invervsion error when running the
+# transpose application standalone. Thus, we disable ThreadSanitizer on PC sampling tests
+# that are using transpose application.
+if(IS_PC_SAMPLING_DISABLED OR ROCPROFILER_MEMCHECK STREQUAL "ThreadSanitizer")
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
 rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.py
                                                           input.json input.yml)
 
@@ -48,7 +57,7 @@ set_tests_properties(
                SKIP_REGULAR_EXPRESSION
                "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
                DISABLED
-               "${IS_PC_SAMPLING_DISABLED}")
+               "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-json-execute
@@ -71,7 +80,7 @@ set_tests_properties(
                SKIP_REGULAR_EXPRESSION
                "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
                DISABLED
-               "${IS_PC_SAMPLING_DISABLED}")
+               "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-yaml-execute
@@ -94,7 +103,7 @@ set_tests_properties(
                SKIP_REGULAR_EXPRESSION
                "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
                DISABLED
-               "${IS_PC_SAMPLING_DISABLED}")
+               "${IS_DISABLED}")
 
 # ========================= Validation tests
 
@@ -123,7 +132,7 @@ set_tests_properties(
         SKIP_REGULAR_EXPRESSION
         "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
         DISABLED
-        "${IS_PC_SAMPLING_DISABLED}")
+        "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-json-validate
@@ -150,7 +159,7 @@ set_tests_properties(
         SKIP_REGULAR_EXPRESSION
         "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
         DISABLED
-        "${IS_PC_SAMPLING_DISABLED}")
+        "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-yaml-validate
@@ -177,4 +186,4 @@ set_tests_properties(
         SKIP_REGULAR_EXPRESSION
         "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
         DISABLED
-        "${IS_PC_SAMPLING_DISABLED}")
+        "${IS_DISABLED}")

--- a/tests/rocprofv3/pc-sampling/stochastic/transpose-multiple-agents/CMakeLists.txt
+++ b/tests/rocprofv3/pc-sampling/stochastic/transpose-multiple-agents/CMakeLists.txt
@@ -35,6 +35,15 @@ find_package(rocprofiler-sdk REQUIRED)
 # Checking whether stochastic PC sampling is disabled. If so, skip the tests.
 rocprofiler_sdk_pc_sampling_stochastic_disabled(IS_PC_SAMPLING_STOCHASTIC_DISABLED)
 
+# For some reason, ThreadSanitizer reports a lock-order-invervsion error when running the
+# transpose application standalone. Thus, we disable ThreadSanitizer on PC sampling tests
+# that are using transpose application.
+if(IS_PC_SAMPLING_DISABLED OR ROCPROFILER_MEMCHECK STREQUAL "ThreadSanitizer")
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
 rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.py
                                                           input.json input.yml)
 
@@ -70,7 +79,7 @@ set_tests_properties(
                SKIP_REGULAR_EXPRESSION
                "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
                DISABLED
-               "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
+               "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-json-execute
@@ -93,7 +102,7 @@ set_tests_properties(
                SKIP_REGULAR_EXPRESSION
                "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
                DISABLED
-               "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
+               "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-yaml-execute
@@ -116,7 +125,7 @@ set_tests_properties(
                SKIP_REGULAR_EXPRESSION
                "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
                DISABLED
-               "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
+               "${IS_DISABLED}")
 
 # ========================= Validation tests
 
@@ -147,7 +156,7 @@ set_tests_properties(
         SKIP_REGULAR_EXPRESSION
         "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
         DISABLED
-        "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
+        "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-json-validate
@@ -176,7 +185,7 @@ set_tests_properties(
         SKIP_REGULAR_EXPRESSION
         "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
         DISABLED
-        "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
+        "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-yaml-validate
@@ -205,4 +214,4 @@ set_tests_properties(
         SKIP_REGULAR_EXPRESSION
         "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
         DISABLED
-        "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
+        "${IS_DISABLED}")


### PR DESCRIPTION
# PR Details

Enable PC sampling tests in our CI. Each test has a guard that should disable it based on the underlying architecture.

All PC sampling tests are disabled on non-GFX9 architectures. Stochastic PC sampling tests are disabled on MI2xx.

## Associated Jira Ticket Number/Link

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Continuous Integration

## Technical details

<!-- Please explain the changes along with JIRA/Github link(if applies). -->
Based on the following [table](https://amd.atlassian.net/wiki/spaces/BLTZ/pages/1015287385/Disabled+Tests), all PC sampling tests are disabled. This PR aims to always set the `ROCPROFILER_PC_SAMPLING_BETA_ENABLED=on` to enable tests to run. However, we used cmake functions to guard running PC sampling tests on the architectures that do not support PC sampling (non gfx9 architectures). This way, the tests are shown as explicitly disabled on the architectures that do not support PC sampling feature. 


## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.
