### PR TITLE
[rocprofv3] Unconditionally collect stream and kernel rename data in rocprofv3 for rocpd

### DIFF
--- a/source/lib/output/generateCSV.cpp
+++ b/source/lib/output/generateCSV.cpp
@@ -288,11 +288,14 @@ generate_csv(const output_config&                                               
     {
         for(auto record : data.get(ditr))
         {
-            auto        row_ss      = std::stringstream{};
-            auto        kernel_name = tool_metadata.get_kernel_name(record.dispatch_info.kernel_id,
-                                                             record.correlation_id.external.value);
+            auto        row_ss = std::stringstream{};
             const auto* kernel_info =
                 tool_metadata.get_kernel_symbol(record.dispatch_info.kernel_id);
+            auto kernel_name =
+                cfg.kernel_rename
+                    ? tool_metadata.get_kernel_name(record.dispatch_info.kernel_id,
+                                                    record.correlation_id.external.value)
+                    : CHECK_NOTNULL(kernel_info)->formatted_kernel_name;
             auto lds_block_size_v =
                 (kernel_info->group_segment_size + (lds_block_size - 1)) & ~(lds_block_size - 1);
 

--- a/source/lib/output/generateCSV.cpp
+++ b/source/lib/output/generateCSV.cpp
@@ -291,11 +291,9 @@ generate_csv(const output_config&                                               
             auto        row_ss = std::stringstream{};
             const auto* kernel_info =
                 tool_metadata.get_kernel_symbol(record.dispatch_info.kernel_id);
-            auto kernel_name =
-                cfg.kernel_rename
-                    ? tool_metadata.get_kernel_name(record.dispatch_info.kernel_id,
-                                                    record.correlation_id.external.value)
-                    : CHECK_NOTNULL(kernel_info)->formatted_kernel_name;
+            auto kernel_name = tool_metadata.get_kernel_name(record.dispatch_info.kernel_id,
+                                                             cfg.kernel_rename,
+                                                             record.correlation_id.external.value);
             auto lds_block_size_v =
                 (kernel_info->group_segment_size + (lds_block_size - 1)) & ~(lds_block_size - 1);
 
@@ -640,7 +638,8 @@ generate_csv(const output_config&                    cfg,
                     record.thread_id,
                     magnitude(record.dispatch_data.dispatch_info.grid_size),
                     record.dispatch_data.dispatch_info.kernel_id,
-                    tool_metadata.get_kernel_name(kernel_id, correlation_id.external.value),
+                    tool_metadata.get_kernel_name(
+                        kernel_id, cfg.kernel_rename, correlation_id.external.value),
                     magnitude(record.dispatch_data.dispatch_info.workgroup_size),
                     lds_block_size_v,
                     record.dispatch_data.dispatch_info.private_segment_size,

--- a/source/lib/output/generateOTF2.cpp
+++ b/source/lib/output/generateOTF2.cpp
@@ -695,8 +695,8 @@ write_otf2(const output_config&                                          cfg,
         const auto* sym  = _get_kernel_sym_data(info);
         CHECK(sym != nullptr);
 
-        auto name =
-            tool_metadata.get_kernel_name(info.kernel_id, itr.correlation_id.external.value);
+        auto name = tool_metadata.get_kernel_name(
+            info.kernel_id, cfg.kernel_rename, itr.correlation_id.external.value);
         _hash_data.emplace(
             get_hash_id(name),
             region_info{std::string{name}, OTF2_REGION_ROLE_FUNCTION, OTF2_PARADIGM_HIP});

--- a/source/lib/output/generateRocpd.cpp
+++ b/source/lib/output/generateRocpd.cpp
@@ -1019,7 +1019,7 @@ write_rocpd(
             }
 
             dispatch_evt_ids.at(dispatch_id) = evt_id;
-
+            // Unconditionally collect kernel rename data if it is available
             auto region_name =
                 (corr_id.external.value > 0 && (enable_duplicate_check || kernel_id > 0))
                     ? tool_metadata.get_kernel_name(kernel_id, corr_id.external.value)

--- a/source/lib/output/generateRocpd.cpp
+++ b/source/lib/output/generateRocpd.cpp
@@ -1022,7 +1022,7 @@ write_rocpd(
             // Unconditionally collect kernel rename data if it is available
             auto region_name =
                 (corr_id.external.value > 0 && (enable_duplicate_check || kernel_id > 0))
-                    ? tool_metadata.get_kernel_name(kernel_id, corr_id.external.value)
+                    ? tool_metadata.get_kernel_name(kernel_id, true, corr_id.external.value)
                     : std::string_view{};
 
             auto agent_node_id = tool_metadata.get_agent(info.agent_id)->node_id;

--- a/source/lib/output/generateStats.cpp
+++ b/source/lib/output/generateStats.cpp
@@ -62,7 +62,7 @@ get_stats(const stats_map_t& data_v)
 }  // namespace
 
 stats_entry_t
-generate_stats(const output_config& /*cfg*/,
+generate_stats(const output_config&                                               cfg,
                const metadata&                                                    tool_metadata,
                const generator<tool_buffer_tracing_kernel_dispatch_ext_record_t>& data)
 {
@@ -72,6 +72,7 @@ generate_stats(const output_config& /*cfg*/,
         for(auto record : data.get(ditr))
         {
             auto kernel_name = tool_metadata.get_kernel_name(record.dispatch_info.kernel_id,
+                                                             cfg.kernel_rename,
                                                              record.correlation_id.external.value);
 
             kernel_stats[kernel_name] += (record.end_timestamp - record.start_timestamp);

--- a/source/lib/output/metadata.cpp
+++ b/source/lib/output/metadata.cpp
@@ -696,19 +696,22 @@ metadata::get_marker_message(uint64_t corr_id) const
 }
 
 std::string_view
-metadata::get_kernel_name(uint64_t kernel_id, uint64_t rename_id) const
+metadata::get_kernel_name(uint64_t kernel_id, bool rename_kernel, uint64_t rename_id) const
 {
-    auto string_entry = kernel_rename_map.rlock(
-        [](auto& _data, uint64_t _val) {
-            for(const auto& itr : _data)
-                if(itr.second == _val) return itr.first;
-            return std::string_view{};
-        },
-        rename_id);
-    if(!string_entry.empty())
+    if(rename_kernel)
     {
-        if(const auto* _name = common::get_string_entry(string_entry))
-            return std::string_view{*_name};
+        auto string_entry = kernel_rename_map.rlock(
+            [](auto& _data, uint64_t _val) {
+                for(const auto& itr : _data)
+                    if(itr.second == _val) return itr.first;
+                return std::string_view{};
+            },
+            rename_id);
+        if(!string_entry.empty())
+        {
+            if(const auto* _name = common::get_string_entry(string_entry))
+                return std::string_view{*_name};
+        }
     }
 
     const auto* _kernel_data = get_kernel_symbol(kernel_id);

--- a/source/lib/output/metadata.hpp
+++ b/source/lib/output/metadata.hpp
@@ -231,7 +231,9 @@ struct metadata
                         const std::vector<std::string>& _command_line = {});
 
     std::string_view   get_marker_message(uint64_t corr_id) const;
-    std::string_view   get_kernel_name(uint64_t kernel_id, uint64_t rename_id) const;
+    std::string_view   get_kernel_name(uint64_t kernel_id,
+                                       bool     rename_kernel,
+                                       uint64_t rename_id) const;
     std::string_view   get_kind_name(rocprofiler_callback_tracing_kind_t kind) const;
     std::string_view   get_kind_name(rocprofiler_buffer_tracing_kind_t kind) const;
     std::string_view   get_operation_name(rocprofiler_callback_tracing_kind_t kind,

--- a/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1995,23 +1995,22 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         start_context(counter_collection_ctx, "counter collection");
     }
 
-
-        auto rename_ctx            = rocprofiler_context_id_t{0};
-        auto marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
-            ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxMarkA,
-            ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxThreadRangeA,
-        };
+    auto rename_ctx            = rocprofiler_context_id_t{0};
+    auto marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
+        ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxMarkA,
+        ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxThreadRangeA,
+    };
 
     ROCPROFILER_CALL(rocprofiler_create_context(&rename_ctx), "failed to create context");
 
-        ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
-                             rename_ctx,
-                             ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_RANGE_API,
-                             marker_core_api_kinds.data(),
-                             marker_core_api_kinds.size(),
-                             callbacks.kernel_rename,
-                             nullptr),
-                         "callback tracing service failed to configure");
+    ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
+                         rename_ctx,
+                         ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_RANGE_API,
+                         marker_core_api_kinds.data(),
+                         marker_core_api_kinds.size(),
+                         callbacks.kernel_rename,
+                         nullptr),
+                     "callback tracing service failed to configure");
 
     start_context(rename_ctx, "kernel rename");
 


### PR DESCRIPTION
# PR Details

## Associated Jira Ticket Number/Link

[SWDEV-540402](https://ontrack-internal.amd.com/browse/SWDEV-540402) [ROCprof V3] Unconditionally collect stream data for rocprofv3

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

The stream info and kernel renaming needs to always be collected for the database in rocpd. In rocpd, they’ll be able to decide whether or not they want to enable kernel renaming and/or streams vs. queue in post-processing so we always need this data collected in the tool. 

## Added/updated tests?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.
