### PR TITLE
Disabling temp. the call to OMPT Tool Finalize

### DIFF
--- a/source/lib/rocprofiler-sdk/ompt.cpp
+++ b/source/lib/rocprofiler-sdk/ompt.cpp
@@ -194,7 +194,12 @@ finalize(ompt_data_t* /*tool_data*/)
 void
 finalize_ompt()
 {
-    if(rocprofiler::ompt::tool_finalize) rocprofiler::ompt::tool_finalize();
+    // As per OMPT spec, this is no need for the tool to call finalize, it is called by the
+    // runtime when the tool is unloaded.
+    // However, we can call it here to ensure that the tool is finalized properly.
+    // But temporarily disable it to avoid issues with the race condition between the runtime
+    // and the tool unloading.
+    // if(rocprofiler::ompt::tool_finalize) rocprofiler::ompt::tool_finalize();
 }
 }  // namespace ompt
 }  // namespace rocprofiler


### PR DESCRIPTION
# PR Details
We are temporarily disabling the OMPT Tool Finalize call to avoid issues with the race condition between the runtime and the tool unloading.

## Associated Jira Ticket Number/Link
[SWDEV-529829](https://ontrack-internal.amd.com/browse/SWDEV-529829)

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

<!-- Please explain the changes along with JIRA/Github link(if applies). -->

## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [X] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [X] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [X] No, Does not apply to this PR.
